### PR TITLE
nix-shell: fix invalid clang-tool parameter in nixpkgs channel 24.11

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -25,7 +25,7 @@ let
 in
 (mkShell.override { stdenv = theStdenv; }) {
   nativeBuildInputs = [
-    (clang-tools.override { llvmPackages = llvmPkgs; })
+    llvmPkgs.clang-tools
     theStdenv.cc.cc.python # git-clang-format
     cmakeCurses # cmake
     pkg-config


### PR DESCRIPTION
clang-tools in nixos channel 24.11 no longer has the parameter `llvmPackages`. The error when instantiating the nix shell with nixpkgs 24.11 is as following

```
error: function 'anonymous lambda' called with unexpected argument 'llvmPackages'
```

Note: I am not super familiar with flakes, not sure if it pining nixpkgs 22.11 is assumed/intended here 